### PR TITLE
fix: joint limits handling in fk

### DIFF
--- a/torch_robotics/torch_kinematics_tree/models/rigid_body.py
+++ b/torch_robotics/torch_kinematics_tree/models/rigid_body.py
@@ -154,7 +154,7 @@ class DifferentiableRigidBody(torch.nn.Module):
             q = q_dict[self.name]
 
             # bound q with limits
-            if self.joint_limits is not None:
+            if self.joint_type != 'continuous' and self.joint_limits is not None:
                 q_clamped = torch.clamp(q, min=self.joint_limits['lower'], max=self.joint_limits['upper'])
             else:
                 q_clamped = q

--- a/torch_robotics/torch_kinematics_tree/models/utils.py
+++ b/torch_robotics/torch_kinematics_tree/models/utils.py
@@ -238,6 +238,10 @@ class URDFRobotModel(RobotModel):
                     "upper": joint.limit.upper,
                     "velocity": joint.limit.velocity,
                 }
+                if joint_type == "continuous":
+                    joint_limits["lower"] = -torch.pi
+                    joint_limits["upper"] = torch.pi
+
                 try:
                     joint_damping = torch.tensor(
                         [joint.dynamics.damping],


### PR DESCRIPTION
@anindex thanks for your project!

When using your project I found that the forward kinematics isn't handling the continuous joint correctly. The reason seems to be because for continuous joint, the `link.joint.lower` and `link.join.upper` fields in the URDF are optional and is initialized to 0 by default. This causes the `clamp` to malfunction and makes the joint to be "fixed" at 0.

I handled the continuous joint specifically during `clamp` and manually set the joint limit to `[-pi, pi]` for joint angle sampling. Not sure if my fix makes sense so feel free to change any of them :)